### PR TITLE
Return remover when calling session.on.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  env: {browser: true},
+  extends: [
+    'digitalbazaar',
+    'digitalbazaar/jsdoc'
+  ]
+};

--- a/Session.js
+++ b/Session.js
@@ -59,7 +59,6 @@ export default class Session {
    * @returns {Function} A unique function to remover the listener.
    */
   on(eventType, handler) {
-    console.log('session on called');
     if(typeof eventType !== 'string') {
       throw new TypeError('"eventType" must be a string.');
     }

--- a/Session.js
+++ b/Session.js
@@ -50,7 +50,7 @@ export default class Session {
   }
 
   /**
-   * Registers a handler that is executed when an event listener fires.
+   * Registers a handler that is executed when an event is emitted.
    *
    * @param {string} eventType - An event such as change.
    * @param {function} handler - A handler function called when

--- a/Session.js
+++ b/Session.js
@@ -65,7 +65,7 @@ export default class Session {
     if(typeof handler !== 'function') {
       throw new TypeError('"handler" must be a function.');
     }
-    // this should return a Map for the eventType.
+    // this returns a Map for `eventType`
     const listeners = this._eventTypeListeners.get(eventType);
     if(!listeners) {
       throw new Error(`Event "${eventType}" is not supported.`);

--- a/Session.js
+++ b/Session.js
@@ -50,10 +50,10 @@ export default class Session {
   }
 
   /**
-   * Registers a callback that is executed when an event listener fires.
+   * Registers a handler that is executed when an event listener fires.
    *
    * @param {string} eventType - An event such as change.
-   * @param {function} handler - A callback function called when
+   * @param {function} handler - A handler function called when
    *   an event occurs.
    *
    * @returns {function} A unique function to remover the listener.

--- a/Session.js
+++ b/Session.js
@@ -49,6 +49,15 @@ export default class Session {
     await this.refresh();
   }
 
+  /**
+   * Registers a callback that is executed when an event listener fires.
+   *
+   * @param {string} eventType - An event such as change.
+   * @param {function} handler - A callback function called when
+   *   an event occurs.
+   *
+   * @returns {function} A unique function to remover the listener.
+   */ 
   on(eventType, handler) {
     if(typeof eventType !== 'string') {
       throw new TypeError('"eventType" must be a string.');
@@ -56,14 +65,17 @@ export default class Session {
     if(typeof handler !== 'function') {
       throw new TypeError('"handler" must be a function.');
     }
-
+    // this should return a Map for the eventType.
     const listeners = this._eventTypeListeners.get(eventType);
     if(!listeners) {
       throw new Error(`Event "${eventType}" is not supported.`);
     }
 
     const remover = () => listeners.delete(remover);
+    // use the function as a unique key in the event listener Map.
     listeners.set(remover, handler);
+    // Return the remover so an external app can remove its listener.
+    return remover;
   }
 
   async _emit(eventType, eventData) {

--- a/Session.js
+++ b/Session.js
@@ -9,7 +9,7 @@ export default class Session {
   constructor() {
     this.data = {};
     this._service = new SessionService();
-    this._eventTypeListeners = new Map([['change', new Map()]]);
+    this._eventTypeListeners = new Map([['change', new Set()]]);
   }
 
   /**
@@ -53,12 +53,13 @@ export default class Session {
    * Registers a handler that is executed when an event is emitted.
    *
    * @param {string} eventType - An event such as "change".
-   * @param {function} handler - A handler function called when
+   * @param {Function} handler - A handler function called when
    *   an event occurs.
    *
-   * @returns {function} A unique function to remover the listener.
-   */ 
+   * @returns {Function} A unique function to remover the listener.
+   */
   on(eventType, handler) {
+    console.log('session on called');
     if(typeof eventType !== 'string') {
       throw new TypeError('"eventType" must be a string.');
     }
@@ -71,16 +72,16 @@ export default class Session {
       throw new Error(`Event "${eventType}" is not supported.`);
     }
 
-    const remover = () => listeners.delete(remover);
-    // use the function as a unique key in the event listener Map.
-    listeners.set(remover, handler);
-    // return the remover so the application can remove the listener
+    const remover = () => listeners.delete(handler);
+    // add the function as a unique element in the event listener Set
+    listeners.add(handler);
+    // return the remover so the application can remove the handler
     return remover;
   }
 
   async _emit(eventType, eventData) {
     const listeners = this._eventTypeListeners.get(eventType);
-    for(const handler of listeners.values()) {
+    for(const handler of listeners) {
       await handler(eventData);
     }
   }

--- a/Session.js
+++ b/Session.js
@@ -52,7 +52,7 @@ export default class Session {
   /**
    * Registers a handler that is executed when an event is emitted.
    *
-   * @param {string} eventType - An event such as change.
+   * @param {string} eventType - An event such as "change".
    * @param {function} handler - A handler function called when
    *   an event occurs.
    *

--- a/Session.js
+++ b/Session.js
@@ -74,7 +74,7 @@ export default class Session {
     const remover = () => listeners.delete(remover);
     // use the function as a unique key in the event listener Map.
     listeners.set(remover, handler);
-    // Return the remover so an external app can remove its listener.
+    // return the remover so the application can remove the listener
     return remover;
   }
 

--- a/package.json
+++ b/package.json
@@ -18,5 +18,10 @@
         "main": "dist/axios.min.js"
       }
     }
+  },
+  "devDependencies": {
+    "eslint": "^6.8.0",
+    "eslint-config-digitalbazaar": "^2.1.0",
+    "eslint-plugin-jsdoc": "^20.3.1"
   }
 }


### PR DESCRIPTION
This fixes a bug where an app can register a listener for an event, but can not remove that listener.