### PR TITLE
Fix store bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-web-session ChangeLog
 
+### 1.5.1 -
+
+### Fixed
+- The id & store passed to `getSession` are passed to `createSession` too.
+
 ## 1.5.0 - 2020-07-01
 
 ### Changed

--- a/main.js
+++ b/main.js
@@ -11,9 +11,9 @@ export {default as SessionService} from './SessionService.js';
 /**
  * Creates a Session with an optional id or store.
  *
- * @param {object} options - Options to use.
- * @param {string} [options.id = 'session.default'] - An id for the session.
- * @param {object} [options.store = defaultStore] - A store for the session.
+ * @param {object} [options={}] - Options to use.
+ * @param {string} [options.id='session.default'] - An id for the session.
+ * @param {object} [options.store=defaultStore] - A store for the session.
  *
  * @returns {object} The created session.
 */
@@ -27,9 +27,9 @@ export const createSession = async (
 /**
  * Gets a session from a store or creates a new session.
  *
- * @param {object} options - Options to use.
- * @param {string} [options.id = 'session.default'] - An id for the session.
- * @param {object} [options.store = defaultStore] - A store for the session.
+ * @param {object} [options={}] - Options to use.
+ * @param {string} [options.id='session.default'] - An id for the session.
+ * @param {object} [options.store=defaultStore] - A store for the session.
  *
  * @returns {object} A session.
 */

--- a/main.js
+++ b/main.js
@@ -8,6 +8,15 @@ import Session from './Session.js';
 
 export {default as SessionService} from './SessionService.js';
 
+/**
+ * Creates a Session with an optional id or store.
+ *
+ * @param {object} options - Options to use.
+ * @param {string} [options.id = 'session.default'] - An id for the session.
+ * @param {object} [options.store = defaultStore] - A store for the session.
+ *
+ * @returns {object} The created session.
+*/
 export const createSession = async (
   {id = 'session.default', store = defaultStore} = {}) => {
   const session = new Session();
@@ -15,6 +24,15 @@ export const createSession = async (
   return session;
 };
 
+/**
+ * Gets a session from a store or creates a new session.
+ *
+ * @param {object} options - Options to use.
+ * @param {string} [options.id = 'session.default'] - An id for the session.
+ * @param {object} [options.store = defaultStore] - A store for the session.
+ *
+ * @returns {object} A session.
+*/
 export const getSession = async (
   {id = 'session.default', store = defaultStore} = {}) => {
   const session = await store.get({id});
@@ -22,7 +40,8 @@ export const getSession = async (
     return session;
   }
   try {
-    const session = await createSession();
+    // use the passed in id and store
+    const session = await createSession({id, store});
     await session.refresh();
     return session;
   } catch(e) {

--- a/main.js
+++ b/main.js
@@ -15,7 +15,7 @@ export {default as SessionService} from './SessionService.js';
  * @param {string} [options.id='session.default'] - An id for the session.
  * @param {object} [options.store=defaultStore] - A store for the session.
  *
- * @returns {object} The created session.
+ * @returns {Promise<object>} The created session.
 */
 export const createSession = async (
   {id = 'session.default', store = defaultStore} = {}) => {
@@ -31,7 +31,7 @@ export const createSession = async (
  * @param {string} [options.id='session.default'] - An id for the session.
  * @param {object} [options.store=defaultStore] - A store for the session.
  *
- * @returns {object} A session.
+ * @returns {Promise<object>} A session.
 */
 export const getSession = async (
   {id = 'session.default', store = defaultStore} = {}) => {


### PR DESCRIPTION
This fixes a small bug where if a user supplies a custom store to `getSession` and the session is not already in the custom store it results in `getSession` creating a new session every time `getSession` is called.

Steps:
1. Create a new store such as one based around a `Set`
2. pass that store and a unique id to `getSession`
3. `getSession` will pass the `id` to your custom store's `get` method
4. `getSession` will not find the session in the custom store
5. `getSession` instead will call on `createSession` with no parameters.
6. `createSession` will create a new store and store a new session with a different id in it each time `getSession` is called.
7. `getSession` will return a new session with a different id (and store ) than the id and store supplied in the parameters.